### PR TITLE
book server 로컬 실행을 위한 config

### DIFF
--- a/api/src/main/resources/application-local.yml
+++ b/api/src/main/resources/application-local.yml
@@ -1,0 +1,36 @@
+grpc:
+  server:
+    port: 9091
+
+spring:
+  jpa:
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+  application:
+    name: book
+    main:
+      allow-circular-references: true
+  servlet:
+    multipart:
+      max-file-size: 10MB
+  image:
+    path: /home/
+  redis:
+    host: localhost
+    port: 6379
+
+springdoc:
+  swagger-ui:
+    base-package: com.ssu.commerce.book
+    title: book api
+    version: 1.0
+
+logging:
+  level:
+    p6spy: info
+    org:
+      springframework:
+        orm:
+          jpa: debug

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,97 @@
+version: '2'
+
+networks:
+  app-tier:
+    driver: bridge
+
+services:
+  redis:
+    image: 'bitnami/redis:latest'
+    environment:
+      - REDIS_REPLICATION_MODE=master
+      - ALLOW_EMPTY_PASSWORD=yes
+    volumes:
+      - ./data/redis:/bitnami/redis
+    networks:
+      - app-tier
+    ports:
+      - 6379:6379
+  redis-slave-1:
+    image: 'bitnami/redis:latest'
+    environment:
+      - REDIS_REPLICATION_MODE=slave
+      - REDIS_MASTER_HOST=redis
+      - ALLOW_EMPTY_PASSWORD=yes
+    volumes:
+      - ./data/rediss1:/bitnami/redis
+    ports:
+      - 6479:6379
+    depends_on:
+      - redis
+    networks:
+      - app-tier
+  redis-slave-2:
+    image: 'bitnami/redis:latest'
+    environment:
+      - REDIS_REPLICATION_MODE=slave
+      - REDIS_MASTER_HOST=redis
+      - ALLOW_EMPTY_PASSWORD=yes
+    volumes:
+      - ./data/rediss2:/bitnami/redis
+    ports:
+      - 6579:6379
+    depends_on:
+      - redis
+    networks:
+      - app-tier
+
+  redis-sentinel:
+    image: 'bitnami/redis-sentinel:latest'
+    environment:
+      - REDIS_SENTINEL_DOWN_AFTER_MILLISECONDS=3000
+      - REDIS_MASTER_HOST=redis
+      - REDIS_MASTER_PORT_NUMBER=6379
+      - REDIS_MASTER_SET=mymaster
+      - REDIS_SENTINEL_QUORUM=2
+    depends_on:
+      - redis
+      - redis-slave-1
+      - redis-slave-2
+    ports:
+      - 26379:26379
+    networks:
+      - app-tier
+
+  redis-sentinel-2:
+    image: 'bitnami/redis-sentinel:latest'
+    environment:
+      - REDIS_SENTINEL_DOWN_AFTER_MILLISECONDS=3000
+      - REDIS_MASTER_HOST=redis
+      - REDIS_MASTER_PORT_NUMBER=6379
+      - REDIS_MASTER_SET=mymaster
+      - REDIS_SENTINEL_QUORUM=2
+    depends_on:
+      - redis
+      - redis-slave-1
+      - redis-slave-2
+    ports:
+      - 26380:26379
+    networks:
+      - app-tier
+
+  redis-sentinel-3:
+    image: 'bitnami/redis-sentinel:latest'
+    environment:
+      - REDIS_SENTINEL_DOWN_AFTER_MILLISECONDS=3000
+      - REDIS_MASTER_HOST=redis
+      - REDIS_MASTER_PORT_NUMBER=6379
+      - REDIS_MASTER_SET=mymaster
+      - REDIS_SENTINEL_QUORUM=2
+    depends_on:
+      - redis
+      - redis-slave-1
+      - redis-slave-2
+    ports:
+      - 26381:26379
+    networks:
+      - app-tier


### PR DESCRIPTION
<!--
title must use prefix like this
feat: new feature
fix: bufix
docs: document changes
style: changes except codes(like indent, import..)
refactor: refactoring
test: test code
chore: about build or deploy(not changes code)
-->

## Changes
로컬 redis 기동을 위한 docker-compose
로컬 프로필 추가
config server에는 local 프로필 반영하여 배포 해두었음

docker-compose로 redis 기동(도커)
 - 현재 docker-compose에는 master, slave 2개, sentinel 3개가 전부 기동
북서버 local 프로필로 실행
## Reason for change

## Detailed Description
![image](https://github.com/ssu-commerce/book-server/assets/85390127/26e6ac54-c552-4d20-8039-e84942a3d97e)
![image](https://github.com/ssu-commerce/book-server/assets/85390127/879ef83f-732e-49d3-ae84-4cb4bb61c165)
![image](https://github.com/ssu-commerce/book-server/assets/85390127/9bbfc2f9-4bb3-4989-9ba0-ea5c93c9ad5c)


## mention
@always0ne
@chohanjoo 
@ccxz84 

Resolves: #
See also: #